### PR TITLE
Ensure all default units are degrees

### DIFF
--- a/gym_solo/core/obs.py
+++ b/gym_solo/core/obs.py
@@ -202,7 +202,6 @@ class TorsoIMU(Observation):
 
     if self._degrees:
       orien = np.degrees(orien)
-    else:
-      v_ang = np.radians(v_ang)
+      v_ang = np.degrees(v_ang)
 
     return np.concatenate([orien, v_lin, v_ang])

--- a/gym_solo/core/test_obs_observations.py
+++ b/gym_solo/core/test_obs_observations.py
@@ -56,14 +56,15 @@ class TestTorsoIMU(unittest.TestCase):
       np.testing.assert_allclose(o.compute(),
                                  [0, 0, 90,
                                   30, 60, 90,
-                                  30, 60, 90])
+                                  30 * 180 / np.pi, 
+                                    60 * 180 / np.pi, 90* 180 / np.pi])
     
     with self.subTest('radians'):
       o = obs.TorsoIMU(0, degrees=False)
       np.testing.assert_allclose(o.compute(),
                                  [0, 0, 1/2 * np.pi,
                                   30, 60, 90,
-                                  1/6 * np.pi, 1/3 * np.pi, 1/2 * np.pi])
+                                  30, 60, 90])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #7. It seems as if according to [this](https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#heading=h.y6v0hy52u8fg) that the outputted values are in radians.

While that documentation is for `GetEulerFromQuaternion`, I feel like values such as angular velocity should just be in rad/sec.