### PR TITLE
Refactor Objects into a Testing Module

### DIFF
--- a/gym_solo/core/test_obs_factory.py
+++ b/gym_solo/core/test_obs_factory.py
@@ -1,20 +1,9 @@
 import unittest
 from gym_solo.core import obs
+from gym_solo.testing import CompliantObs
 
 from gym import spaces
 import numpy as np
-
-
-class CompliantObs(obs.Observation):
-  observation_space = spaces.Box(low=np.array([0., 0.]), 
-                                 high=np.array([3., 3.]))
-  labels = ['1', '2']
-
-  def __init__(self, body_id):
-    pass
-
-  def compute(self):
-    return np.array([1, 2])
 
 
 class TestObservationFactory(unittest.TestCase):

--- a/gym_solo/core/test_rewards_factory.py
+++ b/gym_solo/core/test_rewards_factory.py
@@ -1,18 +1,11 @@
 import unittest
 from gym_solo.core import rewards
+from gym_solo.testing import ReflectiveReward
 
 from parameterized import parameterized
 from unittest import mock
 
 import numpy as np
-
-
-class TestReward(rewards.Reward):
-  def __init__(self, return_value):
-    self._return_value = return_value
-
-  def compute(self):
-    return self._return_value
 
 
 class TestRewardsFactory(unittest.TestCase):
@@ -33,7 +26,7 @@ class TestRewardsFactory(unittest.TestCase):
   def test_register_and_compute(self, name, rewards_dict, expected_reward):
     rf = rewards.RewardFactory()
     for weight, reward in rewards_dict.items():
-      rf.register_reward(weight, TestReward(reward))
+      rf.register_reward(weight, ReflectiveReward(reward))
     self.assertEqual(rf.get_reward(), expected_reward)
 
 

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -2,7 +2,7 @@ import unittest
 from gym_solo.envs import solo8v2vanilla as solo_env
 
 from gym_solo.core.test_obs_factory import CompliantObs
-from gym_solo.core import rewards
+from gym_solo.testing import SimpleReward
 
 from gym import error, spaces
 from parameterized import parameterized
@@ -12,11 +12,6 @@ import importlib
 import numpy as np
 import os
 import pybullet as p
-
-
-class SimpleReward(rewards.Reward):
-  def compute(self):
-    return 1
 
 
 class TestSolo8v2VanillaEnv(unittest.TestCase):

--- a/gym_solo/testing.py
+++ b/gym_solo/testing.py
@@ -1,6 +1,22 @@
+from gym_solo.core import obs
 from gym_solo.core import rewards
+
+from gym import spaces
+import numpy as np
 
 
 class SimpleReward(rewards.Reward):
   def compute(self):
     return 1
+
+
+class CompliantObs(obs.Observation):
+  observation_space = spaces.Box(low=np.array([0., 0.]), 
+                                 high=np.array([3., 3.]))
+  labels = ['1', '2']
+
+  def __init__(self, body_id):
+    pass
+
+  def compute(self):
+    return np.array([1, 2])

--- a/gym_solo/testing.py
+++ b/gym_solo/testing.py
@@ -5,11 +5,6 @@ from gym import spaces
 import numpy as np
 
 
-class SimpleReward(rewards.Reward):
-  def compute(self):
-    return 1
-
-
 class CompliantObs(obs.Observation):
   observation_space = spaces.Box(low=np.array([0., 0.]), 
                                  high=np.array([3., 3.]))
@@ -20,3 +15,16 @@ class CompliantObs(obs.Observation):
 
   def compute(self):
     return np.array([1, 2])
+
+
+class SimpleReward(rewards.Reward):
+  def compute(self):
+    return 1
+
+
+class ReflectiveReward(rewards.Reward):
+  def __init__(self, return_value):
+    self._return_value = return_value
+
+  def compute(self):
+    return self._return_value

--- a/gym_solo/testing.py
+++ b/gym_solo/testing.py
@@ -4,27 +4,62 @@ from gym_solo.core import rewards
 from gym import spaces
 import numpy as np
 
+from gym_solo import solo_types
+
 
 class CompliantObs(obs.Observation):
+  """A simple observation which implements the Observation interface.
+  
+  Note that the observation always returns [1, 2].
+
+  Attributes:
+    observation_space (spaces.Space): The observation space. Always returns a 
+      box with a low of 0 and a high of 3.
+    labels (List[int]): The labels for the two observations. Always returns
+      ['1', '2']
+  """
   observation_space = spaces.Box(low=np.array([0., 0.]), 
                                  high=np.array([3., 3.]))
   labels = ['1', '2']
 
-  def __init__(self, body_id):
+  def __init__(self, body_id: int):
+    """Create a new CompliantObs. Only kept for API conformance."""
     pass
 
-  def compute(self):
-    return np.array([1, 2])
+  def compute(self) -> solo_types.obs:
+    """Compute the observation for the state.
+
+    Returns:
+      solo_types.obs: [1., 2.]
+    """
+    return np.array([1., 2.])
 
 
 class SimpleReward(rewards.Reward):
-  def compute(self):
+  """A reward which will always return 1."""
+  def compute(self) -> float:
+    """'Compute' the reward for the step. Always returns 1.
+
+    Returns:
+      float: 1.0
+    """
     return 1
 
 
 class ReflectiveReward(rewards.Reward):
-  def __init__(self, return_value):
+  """A reward which returns a configurable fixed value."""
+  def __init__(self, return_value: float):
+    """Create a ReflectiveReward.
+
+    Args:
+      return_value (float): What value this reward should return.
+    """
     self._return_value = return_value
 
-  def compute(self):
+  def compute(self) -> float:
+    """Return the fixed reward.
+
+    Returns:
+      float: the configured reward.
+    """
     return self._return_value

--- a/gym_solo/testing.py
+++ b/gym_solo/testing.py
@@ -1,0 +1,6 @@
+from gym_solo.core import rewards
+
+
+class SimpleReward(rewards.Reward):
+  def compute(self):
+    return 1


### PR DESCRIPTION
Closes #13.

As mentioned in the issue, we have a bunch of testing objects in our test file. When we start adding new environments (and associated tests), we'll probably end up re-using those same objects. This PR preemptively refactors the testing objects so that we can avoid the anti-pattern down the line. 