### PR TITLE
Update CI to Support Python 3.7

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Maintain compatibility with 3.6 in case we need to use Pinocchio in the future.
-        # python-version: [3.6, 3.8]
-        python-version: [3.8]
+        # Maintain compatibility with 3.7 due to compatibility with tf 1.
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
[Stable Baselines](https://github.com/hill-a/stable-baselines) seems to rely on Tensorflow 1, which only supports up to Python 3.7. While tf1 is basically deprecated, we should still support 3.7 especially if we are going to be using it in this project. 