### PR TITLE
Solo Env / PyBullet Encapsulation

### DIFF
--- a/gym_solo/core/obs.py
+++ b/gym_solo/core/obs.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from pybullet_utils import bullet_client
 from typing import List, Tuple
 
 import pybullet as p
@@ -13,6 +14,10 @@ from gym_solo import solo_types
 
 
 class Observation(ABC):
+  """An observation for a body in the pybullet simulation.
+  """
+  _client: bullet_client.BulletClient = None
+
   @abstractmethod
   def __init__(self, body_id: int):
     """Create a new Observation.
@@ -58,11 +63,40 @@ class Observation(ABC):
     """
     pass
 
+  @property
+  def client(self) -> bullet_client.BulletClient:
+    """Get the Observation's physics client.
+
+    Raises:
+      ValueError: If the PyBullet client hasn't been set yet.
+
+    Returns:
+      bullet_client.BulletClient: The active client for the observation.
+    """
+    if not self._client:
+      raise ValueError('PyBullet client needs to be set')
+    return self._client
+
+  @client.setter
+  def client(self, client: bullet_client.BulletClient):
+    """Set the Observation's physics client.
+
+    Args:
+      client (bullet_client.BulletClient): The client to use for the 
+        observation.
+    """
+    self._client = client
+
 
 class ObservationFactory:
-  def __init__(self):
+  def __init__(self, client: bullet_client.BulletClient):
     """Create a new Observation Factory.
+
+    Args:
+      client (bullet_client.BulletClient): Pybullet client to perform 
+        calculations.
     """
+    self._client = client
     self._observations = []
     self._obs_space = None
 
@@ -72,6 +106,8 @@ class ObservationFactory:
     Args:
       obs (Observation): Observation to be tracked.
     """
+    obs.client = self._client
+
     lbl_len = len(obs.labels)
     obs_space_len = len(obs.observation_space.low)
     obs_len = obs.compute().size
@@ -191,12 +227,12 @@ class TorsoIMU(Observation):
       solo_types.obs: The observation for the current state (accessed via
         pybullet)
     """
-    _, orien_quat = p.getBasePositionAndOrientation(self.robot)
+    _, orien_quat = self.client.getBasePositionAndOrientation(self.robot)
 
     # Orien is in (x, y, z)
-    orien = np.array(p.getEulerFromQuaternion(orien_quat))
+    orien = np.array(self.client.getEulerFromQuaternion(orien_quat))
 
-    v_lin, v_ang = p.getBaseVelocity(self.robot)
+    v_lin, v_ang = self.client.getBaseVelocity(self.robot)
     v_lin = np.array(v_lin) 
     v_ang = np.array(v_ang)
 
@@ -222,7 +258,10 @@ class MotorEncoder(Observation):
     """
     self.robot = body_id
     self._degrees = degrees
-    self._num_joints = p.getNumJoints(self.robot)
+
+  @property
+  def _num_joints(self):
+    return self.client.getNumJoints(self.robot)
   
   @property
   def observation_space(self) -> spaces.Space:
@@ -234,7 +273,7 @@ class MotorEncoder(Observation):
     lower, upper = [], []
 
     for joint in range(self._num_joints):
-      joint_info = p.getJointInfo(self.robot, joint)
+      joint_info = self.client.getJointInfo(self.robot, joint)
       lower.append(joint_info[8])
       upper.append(joint_info[9])
 
@@ -247,6 +286,7 @@ class MotorEncoder(Observation):
 
     return spaces.Box(low=lower, high=upper)
 
+  @property
   def labels(self) -> List[str]:
     """A list of labels corresponding to the observation.
 
@@ -254,8 +294,8 @@ class MotorEncoder(Observation):
       List[str]: Labels, where the index is the same as its respective 
       observation.
     """
-    return [p.getJointInfo(self.robot, joint)[1].decode('UTF-8') 
-              for joint in range(self._num_joints)]
+    return [self.client.getJointInfo(self.robot, joint)[1].decode('UTF-8') 
+            for joint in range(self._num_joints)]
 
   def compute(self) -> solo_types.obs:
     """Computes the motor position values all the joints of the robot 
@@ -264,11 +304,10 @@ class MotorEncoder(Observation):
     Returns:
       solo_types.obs: The observation extracted from pybullet
     """
-    joint_values = np.array([p.getJointState(self.robot, i)[0] 
-                    for i in range(self._num_joints)])
+    joint_values = np.array([self.client.getJointState(self.robot, i)[0] 
+                             for i in range(self._num_joints)])
 
     if self._degrees:
       joint_values = np.degrees(joint_values)
       
     return joint_values
-    

--- a/gym_solo/core/obs.py
+++ b/gym_solo/core/obs.py
@@ -15,6 +15,10 @@ from gym_solo import solo_types
 
 class Observation(ABC):
   """An observation for a body in the pybullet simulation.
+
+  Attributes:
+    _client: The PyBullet client for the instance. Will be set via a
+      property setter.
   """
   _client: bullet_client.BulletClient = None
 

--- a/gym_solo/core/test_obs_observations.py
+++ b/gym_solo/core/test_obs_observations.py
@@ -200,7 +200,7 @@ class TestMotorEncoder(ObservationBaseTestCase):
      'HR_HFE', 'HR_KFE', 'HR_ANKLE']
 
     o = self.build_obs(dummy_robot_id)
-    self.assertEqual(o.labels(), ground_truth)
+    self.assertEqual(o.labels, ground_truth)
     
   @parameterized.expand([
     ("default", False),

--- a/gym_solo/core/test_obs_observations.py
+++ b/gym_solo/core/test_obs_observations.py
@@ -1,20 +1,44 @@
 import unittest
 from gym_solo.core import obs
 
+from abc import ABC, abstractmethod
 from parameterized import parameterized
+from pybullet_utils import bullet_client
 from unittest import mock
 
-import numpy as np
 import math
+import numpy as np
+import pybullet as p
 
 
-class TestTorsoIMU(unittest.TestCase):
+class ObservationBaseTestCase(unittest.TestCase, ABC):
+  @property
+  @abstractmethod
+  def obs_cls(self):
+    """The observation class to instantiate."""
+    pass
+
+  def setUp(self):
+    self.client = bullet_client.BulletClient(connection_mode=p.DIRECT)
+
+  def tearDown(self):
+    self.client.disconnect()
+
+  def build_obs(self, *args, **kwargs):
+    o = self.obs_cls(*args, **kwargs)
+    o.client = self.client
+    return o
+
+
+class TestTorsoIMU(ObservationBaseTestCase):
+  obs_cls = obs.TorsoIMU
+
   @parameterized.expand([
     ('default', 0, False),
     ('degrees', 1, True)
   ])
   def test_attributes(self, name, robot_id, degrees):
-    o = obs.TorsoIMU(robot_id, degrees=degrees)
+    o = self.build_obs(robot_id, degrees=degrees)
     self.assertEqual(o.robot, robot_id)
     self.assertEqual(o._degrees, degrees)
 
@@ -23,7 +47,7 @@ class TestTorsoIMU(unittest.TestCase):
     ('radians', -np.pi, np.pi)
   ])
   def test_bounds(self, name, angle_min, angle_max):
-    o = obs.TorsoIMU(0, name == 'degrees')
+    o = self.build_obs(0, degrees=(name=='degrees'))
 
     angles = {'θx', 'θy', 'θz'}
     space_len = len(o.labels)
@@ -43,8 +67,8 @@ class TestTorsoIMU(unittest.TestCase):
     # https://github.com/openai/gym/blob/master/gym/spaces/box.py#L66-L67
     self.assertFalse(o.observation_space.is_bounded())
 
-  @mock.patch('pybullet.getBasePositionAndOrientation', autospec=True)
-  @mock.patch('pybullet.getBaseVelocity', autospec=True)
+  @mock.patch('pybullet.getBasePositionAndOrientation')
+  @mock.patch('pybullet.getBaseVelocity')
   def test_compute(self, mock_vel, mock_base):
     mock_base.return_value = (None, 
                               [0, 0, 0.707, 0.707])
@@ -52,7 +76,7 @@ class TestTorsoIMU(unittest.TestCase):
                               [30, 60, 90])
 
     with self.subTest('degrees'):
-      o = obs.TorsoIMU(0, degrees=True)
+      o = self.build_obs(0, degrees=True)
       np.testing.assert_allclose(o.compute(),
                                  [0, 0, 90,
                                   30, 60, 90,
@@ -60,14 +84,15 @@ class TestTorsoIMU(unittest.TestCase):
                                     60 * 180 / np.pi, 90* 180 / np.pi])
 
     with self.subTest('radians'):
-      o = obs.TorsoIMU(0, degrees=False)
+      o = self.build_obs(0, degrees=True)
       np.testing.assert_allclose(o.compute(),
                                  [0, 0, 1/2 * np.pi,
                                   30, 60, 90,
                                   30, 60, 90])
 
 
-class TestMotorEncoder(unittest.TestCase):
+class TestMotorEncoder(ObservationBaseTestCase):
+  obs_cls = obs.MotorEncoder
 
   def __init__(self, *args, **kwargs):
     super(TestMotorEncoder, self).__init__(*args, **kwargs)
@@ -121,13 +146,13 @@ class TestMotorEncoder(unittest.TestCase):
     ("default", False),
     ("degrees", True)
   ])
-  @mock.patch('pybullet.getNumJoints', autospec=True)
+  @mock.patch('pybullet.getNumJoints')
   def test_attributes(self, name, degrees, mock_num_joints):
     num_joints = 12
     dummy_robot_id = 0
     mock_num_joints.return_value = num_joints
 
-    o = obs.MotorEncoder(dummy_robot_id, degrees=degrees)
+    o = self.build_obs(dummy_robot_id, degrees=degrees)
     
     self.assertEqual(o.robot, dummy_robot_id)
     self.assertEqual(o._degrees, degrees)
@@ -137,8 +162,8 @@ class TestMotorEncoder(unittest.TestCase):
     ("default", False),
     ("degrees", True)
   ])
-  @mock.patch('pybullet.getJointInfo', autospec=True)
-  @mock.patch('pybullet.getNumJoints', autospec=True)
+  @mock.patch('pybullet.getJointInfo')
+  @mock.patch('pybullet.getNumJoints')
   def test_observation_space(self, name, degrees, mock_num_joints, mock_joint_info):
 
     num_joints = 12
@@ -146,7 +171,7 @@ class TestMotorEncoder(unittest.TestCase):
     mock_joint_info.side_effect = lambda robot, joint: self.joint_info[joint]
     dummy_robot_id = 0
 
-    o = obs.MotorEncoder(dummy_robot_id, degrees=degrees)
+    o = self.build_obs(dummy_robot_id, degrees=degrees)
 
     position_max = 10
 
@@ -161,8 +186,8 @@ class TestMotorEncoder(unittest.TestCase):
     np.testing.assert_allclose(o.observation_space.low, lower_bound)
     np.testing.assert_allclose(o.observation_space.high, upper_bound)
 
-  @mock.patch('pybullet.getJointInfo', autospec=True)
-  @mock.patch('pybullet.getNumJoints', autospec=True)
+  @mock.patch('pybullet.getJointInfo')
+  @mock.patch('pybullet.getNumJoints')
   def test_labels(self, mock_num_joints, mock_joint_info):
     num_joints = 12
     dummy_robot_id = 0
@@ -174,15 +199,15 @@ class TestMotorEncoder(unittest.TestCase):
      'FR_KFE', 'FR_ANKLE', 'HL_HFE', 'HL_KFE', 'HL_ANKLE',
      'HR_HFE', 'HR_KFE', 'HR_ANKLE']
 
-    o = obs.MotorEncoder(dummy_robot_id)
+    o = self.build_obs(dummy_robot_id)
     self.assertEqual(o.labels(), ground_truth)
     
   @parameterized.expand([
     ("default", False),
     ("degrees", True)
   ])
-  @mock.patch('pybullet.getJointState', autospec=True)
-  @mock.patch('pybullet.getNumJoints', autospec=True)
+  @mock.patch('pybullet.getJointState')
+  @mock.patch('pybullet.getNumJoints')
   def test_compute(self, name, degrees, mock_num_joints, mock_joint_state):
     dummy_robot_id = 0
 
@@ -213,7 +238,7 @@ class TestMotorEncoder(unittest.TestCase):
     if degrees:
       ground_truth = np.degrees(ground_truth)
 
-    o = obs.MotorEncoder(dummy_robot_id, degrees=degrees)
+    o = self.build_obs(dummy_robot_id, degrees=degrees)
     np.testing.assert_allclose(o.compute(), ground_truth)
 
 

--- a/gym_solo/core/test_obs_observations.py
+++ b/gym_solo/core/test_obs_observations.py
@@ -84,7 +84,7 @@ class TestTorsoIMU(ObservationBaseTestCase):
                                     60 * 180 / np.pi, 90* 180 / np.pi])
 
     with self.subTest('radians'):
-      o = self.build_obs(0, degrees=True)
+      o = self.build_obs(0, degrees=False)
       np.testing.assert_allclose(o.compute(),
                                  [0, 0, 1/2 * np.pi,
                                   30, 60, 90,

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -35,9 +35,6 @@ class Solo8VanillaEnv(gym.Env):
     self._realtime = realtime
     self._config = config
 
-    self.obs_factory = obs.ObservationFactory()
-    self.reward_factory = rewards.RewardFactory()
-
     self.client = bc.BulletClient(
       connection_mode=p.GUI if use_gui else p.DIRECT)
     self.client.setAdditionalSearchPath(pbd.getDataPath())
@@ -47,6 +44,9 @@ class Solo8VanillaEnv(gym.Env):
 
     self.plane = self.client.loadURDF('plane.urdf')
     self.robot, joint_cnt = self._load_robot()
+
+    self.obs_factory = obs.ObservationFactory(self.client)
+    self.reward_factory = rewards.RewardFactory()
 
     self._zero_gains = np.zeros(joint_cnt)
     self.action_space = spaces.Box(-self._config.motor_torque_limit, 

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -5,6 +5,7 @@ import numpy as np
 import pkg_resources
 import pybullet as p
 import pybullet_data as pbd
+import pybullet_utils.bullet_client as bc
 import random
 import time
 
@@ -37,12 +38,14 @@ class Solo8VanillaEnv(gym.Env):
     self.obs_factory = obs.ObservationFactory()
     self.reward_factory = rewards.RewardFactory()
 
-    self._client = p.connect(p.GUI if use_gui else p.DIRECT)
-    p.setAdditionalSearchPath(pbd.getDataPath())
-    p.setGravity(*self._config.gravity)
-    p.setPhysicsEngineParameter(fixedTimeStep=self._config.dt, numSubSteps=1)
+    self.client = bc.BulletClient(
+      connection_mode=p.GUI if use_gui else p.DIRECT)
+    self.client.setAdditionalSearchPath(pbd.getDataPath())
+    self.client.setGravity(*self._config.gravity)
+    self.client.setPhysicsEngineParameter(fixedTimeStep=self._config.dt, 
+                                          numSubSteps=1)
 
-    self.plane = p.loadURDF('plane.urdf')
+    self.plane = self.client.loadURDF('plane.urdf')
     self.robot, joint_cnt = self._load_robot()
 
     self._zero_gains = np.zeros(joint_cnt)
@@ -65,12 +68,12 @@ class Solo8VanillaEnv(gym.Env):
         observation, the reward for that step, whether or not the episode 
         terminates, and an info dict for misc diagnostic details.
     """
-    p.setJointMotorControlArray(self.robot, 
+    self.client.setJointMotorControlArray(self.robot, 
                                 np.arange(self.action_space.shape[0]),
                                 p.TORQUE_CONTROL, forces=action,
                                 positionGains=self._zero_gains, 
                                 velocityGains=self._zero_gains)
-    p.stepSimulation()
+    self.client.stepSimulation()
 
     if self._realtime:
       time.sleep(self._config.dt)
@@ -86,17 +89,16 @@ class Solo8VanillaEnv(gym.Env):
     Returns:
       solo_types.obs: The initial observation of the space.
     """
-    p.removeBody(self.robot)
+    self.client.removeBody(self.robot)
     self.robot, _ = self._load_robot()
 
     # Let gravity do it's thing and reset the environment deterministically
     for i in range(1000):
-      p.setJointMotorControlArray(self.robot, 
-                                  np.arange(self.action_space.shape[0]),
-                                  p.TORQUE_CONTROL, forces=self._zero_gains,
-                                  positionGains=self._zero_gains, 
-                                  velocityGains=self._zero_gains)
-      p.stepSimulation()
+      self.client.setJointMotorControlArray(
+        self.robot, np.arange(self.action_space.shape[0]), 
+        p.TORQUE_CONTROL, forces=self._zero_gains, 
+        positionGains=self._zero_gains, velocityGains=self._zero_gains)
+      self.client.stepSimulation()
     
     obs_values, _ = self.obs_factory.get_obs()
     return obs_values
@@ -112,27 +114,29 @@ class Solo8VanillaEnv(gym.Env):
     Returns:
         Tuple[int, int]: the id of the robot object and the number of joints.
     """
-    robot_id = p.loadURDF(
+    robot_id = self.client.loadURDF(
       self._config.urdf, self._config.robot_start_pos, 
-      p.getQuaternionFromEuler(self._config.robot_start_orientation_euler),
+      self.client.getQuaternionFromEuler(
+        self._config.robot_start_orientation_euler),
       flags=p.URDF_USE_INERTIA_FROM_FILE, useFixedBase=False)
 
-    joint_cnt = p.getNumJoints(robot_id)
-    p.setJointMotorControlArray(robot_id, np.arange(joint_cnt),
-                                p.VELOCITY_CONTROL, forces=np.zeros(joint_cnt))
+    joint_cnt = self.client.getNumJoints(robot_id)
+    self.client.setJointMotorControlArray(robot_id, np.arange(joint_cnt),
+                                          p.VELOCITY_CONTROL, 
+                                          forces=np.zeros(joint_cnt))
 
     for joint in range(joint_cnt):
-      p.changeDynamics(robot_id, joint, 
-                       linearDamping=self._config.linear_damping,
-                       angularDamping=self._config.angular_damping,
-                       restitution=self._config.restitution,
-                       lateralFriction=self._config.lateral_friction)
+      self.client.changeDynamics(robot_id, joint, 
+                                 linearDamping=self._config.linear_damping, 
+                                 angularDamping=self._config.angular_damping, 
+                                 restitution=self._config.restitution, 
+                                 lateralFriction=self._config.lateral_friction)
 
     return robot_id, joint_cnt
 
   def _close(self) -> None:
     """Soft shutdown the environment. """
-    p.disconnect()
+    self.client.disconnect()
 
   def _seed(self, seed: int) -> None:
     """Set the seeds for random and numpy

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -12,6 +12,7 @@ import importlib
 import numpy as np
 import os
 import pybullet as p
+import pybullet_utils.bullet_client as bc
 
 
 class SimpleReward(rewards.Reward):
@@ -74,11 +75,11 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     ('nogui', {'use_gui': False}, p.DIRECT),
     ('gui', {'use_gui': True}, p.GUI),
   ])
-  @mock.patch('pybullet.connect')
-  def test_GUI(self, name, kwargs, expected_ui, mock_connect):
+  @mock.patch('pybullet_utils.bullet_client.BulletClient')
+  def test_GUI(self, name, kwargs, expected_ui, mock_client):
     env = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig(),
                                    **kwargs)
-    mock_connect.assert_called_with(expected_ui)
+    mock_client.assert_called_with(connection_mode=expected_ui)
 
   def test_action_space(self):
     limit = 0.5

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -3,6 +3,7 @@ from gym_solo.envs import solo8v2vanilla as solo_env
 
 from gym_solo.core.test_obs_factory import CompliantObs
 from gym_solo.core import rewards
+from gym_solo.core import obs as solo_obs
 
 from gym import error, spaces
 from parameterized import parameterized
@@ -149,6 +150,22 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     o = CompliantObs(None)
     self.env.obs_factory.register_observation(o)
     self.assertEqual(o.observation_space, self.env.observation_space)
+
+  def test_disjoint_environments(self):
+    env1 = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
+    env1.obs_factory.register_observation(solo_obs.TorsoIMU(env1.robot))
+    env1.obs_factory.register_observation(solo_obs.MotorEncoder(env1.robot))
+
+    home_position = env1.reset()
+    
+    for i in range(1000):
+      env1.step(env1.action_space.sample())
+
+    env2 = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
+    env2.obs_factory.register_observation(solo_obs.TorsoIMU(env2.robot))
+    env2.obs_factory.register_observation(solo_obs.MotorEncoder(env2.robot))
+
+    np.testing.assert_array_almost_equal(home_position, env2.reset())
 
 if __name__ == '__main__':
   unittest.main()

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -1,9 +1,8 @@
 import unittest
 from gym_solo.envs import solo8v2vanilla as solo_env
 
-from gym_solo.core.test_obs_factory import CompliantObs
-from gym_solo.core import rewards
 from gym_solo.core import obs as solo_obs
+from gym_solo.testing import CompliantObs
 from gym_solo.testing import SimpleReward
 
 from gym import error, spaces
@@ -151,6 +150,7 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env1 = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
     env1.obs_factory.register_observation(solo_obs.TorsoIMU(env1.robot))
     env1.obs_factory.register_observation(solo_obs.MotorEncoder(env1.robot))
+    env1.reward_factory.register_reward(1, SimpleReward())
 
     home_position = env1.reset()
     
@@ -160,6 +160,7 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env2 = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
     env2.obs_factory.register_observation(solo_obs.TorsoIMU(env2.robot))
     env2.obs_factory.register_observation(solo_obs.MotorEncoder(env2.robot))
+    env2.reward_factory.register_reward(1, SimpleReward())
 
     np.testing.assert_array_almost_equal(home_position, env2.reset())
 


### PR DESCRIPTION
Closes #18.

Since PyBullet's GUI functionality is dependent upon the initialization, the best way to train + demo a net would be the following:
1. Create a non-gui env
2. Train the model on that for speed
3. Create a gui env
4. Perform demonstrations on that environment

Previously, all of the gym environments had shared the global PyBullet pointer, so all of the calculations ended up conflicting. Thus the only way to render the environment would be to save / load the model between a training script and a rendering script. This PR makes it so that everything can be done in one script.

This functionality has been tested + working empirically in a Jupyter notebook.

@mahajanrevant, watch out, this is also going to affect how your `Termination` objects work as well in #27 and #19.