### PR TITLE
Adding reward instance to the examples to make them work

### DIFF
--- a/examples/solo8_vanilla/interactive.py
+++ b/examples/solo8_vanilla/interactive.py
@@ -9,12 +9,15 @@ import numpy as np
 
 import gym_solo
 from gym_solo.envs import solo8v2vanilla
+from gym_solo.core import rewards
 
 
 if __name__ == '__main__':
   config = solo8v2vanilla.Solo8VanillaConfig()
   env = gym.make('solo8vanilla-v0', use_gui=True, realtime=True, config=config)
 
+  env.reward_factory.register_reward(1,rewards.UprightReward(env.robot))
+  
   try:
     print("""\n
           =========================

--- a/examples/solo8_vanilla/observation_dump.py
+++ b/examples/solo8_vanilla/observation_dump.py
@@ -10,6 +10,7 @@ import numpy as np
 import gym_solo
 from gym_solo.envs import solo8v2vanilla
 from gym_solo.core import obs
+from gym_solo.core import rewards
 
 
 if __name__ == '__main__':
@@ -17,6 +18,7 @@ if __name__ == '__main__':
   env = gym.make('solo8vanilla-v0', use_gui=True, realtime=True, config=config)
 
   env.obs_factory.register_observation(obs.TorsoIMU(env.robot))
+  env.reward_factory.register_reward(1,rewards.UprightReward(env.robot))
 
   try:
     print("""\n

--- a/gym_solo/core/obs.py
+++ b/gym_solo/core/obs.py
@@ -134,7 +134,7 @@ class ObservationFactory:
         i-th observation.
     """
     if not self._observations:
-      return np.empty(shape=(0,)), []
+      raise ValueError('Need to register at least one observation instance')
 
     all_obs = [] 
     all_labels = []

--- a/gym_solo/core/termination.py
+++ b/gym_solo/core/termination.py
@@ -40,8 +40,8 @@ class TerminationFactory:
     termination conditions and value of _is_or attribute
     """
     
-    if not self._use_or:
-      raise ValueError('No termination condition other than OR is defined')
+    if not self._terminations:
+      raise ValueError('Need to register at least one termination instance')
 
     for termination in self._terminations:
       if termination.is_terminated():

--- a/gym_solo/core/test_obs_factory.py
+++ b/gym_solo/core/test_obs_factory.py
@@ -22,9 +22,8 @@ class TestObservationFactory(unittest.TestCase):
     self.assertFalse(of._observations)
     self.assertIsNone(of._obs_space)
 
-    observations, labels = of.get_obs()
-    self.assertEqual(observations.size, 0)
-    self.assertFalse(labels)
+    with self.assertRaises(ValueError):
+      observations, labels = of.get_obs()
 
   def test_register_happy(self):
     of = obs.ObservationFactory(self.client)
@@ -70,10 +69,9 @@ class TestObservationFactory(unittest.TestCase):
 
   def test_get_obs_no_observations(self):
     of = obs.ObservationFactory(self.client)
-    observations, labels = of.get_obs()
     
-    np.testing.assert_array_equal(observations, np.empty(shape=(0,)))
-    self.assertFalse(labels)
+    with self.assertRaises(ValueError):
+      observations, labels = of.get_obs()
 
   def test_get_obs_single_observation(self):
     of = obs.ObservationFactory(self.client)

--- a/gym_solo/core/test_termination_factory.py
+++ b/gym_solo/core/test_termination_factory.py
@@ -1,19 +1,6 @@
 import unittest
 from gym_solo.core import termination
-
-# TODO: Move this to gym_solo.testing
-class DummyTermination(termination.Termination):
-  def __init__(self, body_id: int, termination_var: bool):
-    self.body_id = body_id
-    self.termination_var = termination_var
-    self.reset_counter = 0
-    self.reset()
-    
-  def reset(self):
-    self.reset_counter += 1
-
-  def is_terminated(self) -> bool:
-    return self.termination_var
+from gym_solo.testing import DummyTermination
 
 
 class TestTerminationFactory(unittest.TestCase):

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -55,7 +55,7 @@ class Solo8VanillaEnv(gym.Env):
                                    self._config.motor_torque_limit,
                                    shape=(joint_cnt,))
     
-    self.reset()
+    self.reset(init_call=True)
 
   def step(self, action: List[float]) -> Tuple[solo_types.obs, float, bool, 
                                                 Dict[Any, Any]]:
@@ -88,7 +88,7 @@ class Solo8VanillaEnv(gym.Env):
 
     return obs_values, reward, done, {'labels': obs_labels}
 
-  def reset(self) -> solo_types.obs:
+  def reset(self, init_call: bool = False) -> solo_types.obs:
     """Reset the state of the environment and returns an initial observation.
     
     Returns:
@@ -106,8 +106,11 @@ class Solo8VanillaEnv(gym.Env):
         positionGains=self._zero_gains, velocityGains=self._zero_gains)
       self.client.stepSimulation()
     
-    obs_values, _ = self.obs_factory.get_obs()
-    return obs_values
+    if init_call:
+      return np.empty(shape=(0,)), []
+    else:
+      obs_values, _ = self.obs_factory.get_obs()
+      return obs_values
   
   @property
   def observation_space(self):

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -4,6 +4,7 @@ from gym_solo.envs import solo8v2vanilla as solo_env
 from gym_solo.core import obs as solo_obs
 from gym_solo.testing import CompliantObs
 from gym_solo.testing import SimpleReward
+from gym_solo.testing import DummyTermination
 
 from gym import error, spaces
 from parameterized import parameterized
@@ -36,7 +37,10 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig(),
                                    realtime=True)
     env.reward_factory.register_reward(1, SimpleReward())
-
+    
+    env.obs_factory.register_observation(CompliantObs(None))
+    env.termination_factory.register_termination(DummyTermination(0, True))
+    
     env.step(env.action_space.sample())
     self.assertTrue(mock_time.called)
     
@@ -91,7 +95,10 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
 
   def test_actions(self):
     no_op = np.zeros(self.env.action_space.shape[0])
-
+    
+    self.env.obs_factory.register_observation(CompliantObs(None))
+    self.env.termination_factory.register_termination(DummyTermination(0, True))
+    
     # Let the robot stabilize first
     for i in range(1000):
       self.env.step(no_op)
@@ -116,6 +123,9 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
       self.assert_array_not_almost_equal(orientation, new_or)
 
   def test_reset(self):
+    self.env.obs_factory.register_observation(CompliantObs(None))
+    self.env.termination_factory.register_termination(DummyTermination(0, True))
+    
     base_pos, base_or = p.getBasePositionAndOrientation(self.env.robot)
     
     action = np.array([5.] * self.env.action_space.shape[0])
@@ -138,6 +148,9 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
       env.step(np.zeros(self.env.action_space.shape[0]))
 
   def test_step_simple_reward(self):
+    self.env.obs_factory.register_observation(CompliantObs(None))
+    self.env.termination_factory.register_termination(DummyTermination(0, True))
+    
     obs, reward, done, info = self.env.step(self.env.action_space.sample())
     self.assertEqual(reward, 1)
 
@@ -151,7 +164,7 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env1.obs_factory.register_observation(solo_obs.TorsoIMU(env1.robot))
     env1.obs_factory.register_observation(solo_obs.MotorEncoder(env1.robot))
     env1.reward_factory.register_reward(1, SimpleReward())
-
+    env1.termination_factory.register_termination(DummyTermination(0, True))
     home_position = env1.reset()
     
     for i in range(1000):
@@ -161,6 +174,7 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env2.obs_factory.register_observation(solo_obs.TorsoIMU(env2.robot))
     env2.obs_factory.register_observation(solo_obs.MotorEncoder(env2.robot))
     env2.reward_factory.register_reward(1, SimpleReward())
+    env2.termination_factory.register_termination(DummyTermination(0, True))
 
     np.testing.assert_array_almost_equal(home_position, env2.reset())
 

--- a/gym_solo/testing.py
+++ b/gym_solo/testing.py
@@ -1,5 +1,6 @@
 from gym_solo.core import obs
 from gym_solo.core import rewards
+from gym_solo.core import termination
 
 from gym import spaces
 import numpy as np
@@ -63,3 +64,17 @@ class ReflectiveReward(rewards.Reward):
       float: the configured reward.
     """
     return self._return_value
+
+
+class DummyTermination(termination.Termination):
+  def __init__(self, body_id: int, termination_var: bool):
+    self.body_id = body_id
+    self.termination_var = termination_var
+    self.reset_counter = 0
+    self.reset()
+    
+  def reset(self):
+    self.reset_counter += 1
+
+  def is_terminated(self) -> bool:
+    return self.termination_var


### PR DESCRIPTION
I was playing around with the examples. Realized that at least one reward is needed otherwise an exception is raised. Fixed the issue. Possibly discovered another issue where we need to have a similar minimum limit with the observations. As of now, there is no error raised if there are zero observations registered. Should we implement this check? Thoughts?