### PR TITLE
Refactor Solo8v2 Vanilla Env to Follow OOP

### DIFF
--- a/gym_solo/envs/__init__.py
+++ b/gym_solo/envs/__init__.py
@@ -1,5 +1,6 @@
 """Custom solo environments"""
-
+# Base (abstract) environment
+from gym_solo.envs.solo8_base_env import Solo8BaseEnv
 
 # First party model
 from gym_solo.envs.solo8v2vanilla import Solo8VanillaEnv

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -66,6 +66,15 @@ class Solo8BaseEnv(ABC, gym.Env):
     """
     pass
 
+  @property
+  def observation_space(self):
+    """Get the agent's observation space.
+
+    Returns:
+      gym.Space: The agent's observation space.
+    """
+    return self.obs_factory.get_observation_space()
+
   def _close(self):
     """Soft shutdown the environment."""
     self.client.disconnect()

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -44,7 +44,7 @@ class Solo8BaseEnv(gym.Env, ABC):
     self.reset(init_call=True)
 
   @abstractmethod
-  def reset(init_call: bool = False):
+  def reset(self, init_call: bool = False):
     """Reset the environment.
     
     For best results, this method should be deterministic; i.e. the environment
@@ -53,5 +53,15 @@ class Solo8BaseEnv(gym.Env, ABC):
     Args:
       init_call (bool, optional): If this function is being called from the init
         function. Defaults to False.
+    """
+    pass
+
+  @abstractmethod
+  def load_bodies(self):
+    """Load the bodies into the environment. 
+    
+    Note that a plane has already been loaded in and the entire environment
+    is encapsulated within the self.client object. Thus, all bodies should
+    be added via the self.client interface.
     """
     pass

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -1,0 +1,43 @@
+import abc
+import gym
+import pybullet as p
+import pybullet_data as pbd
+import pybullet_utils.bullet_client as bc
+
+from gym_solo.core import termination as terms
+from gym_solo.core import configs
+from gym_solo.core import obs
+from gym_solo.core import rewards
+
+
+class Solo8BaseEnv(gym.Env, abc.ABC):
+  """Solo 8 abstract base environment."""
+  def __init__(self, config: configs.Solo8BaseConfig, use_gui: bool, 
+               realtime: bool):
+    """Create a solo8 env.
+
+    Args:
+      config (configs.Solo8BaseConfig): The SoloConfig. Defaults to None.
+      use_gui (bool): Whether or not to show the pybullet GUI. Defaults to 
+        False.
+      realtime (bool): Whether or not to run the simulation in real time. 
+        Defaults to False.
+    """
+    self._realtime = realtime
+    self._config = config
+
+    self.client = bc.BulletClient(
+      connection_mode=p.GUI if use_gui else p.DIRECT)
+    self.client.setAdditionalSearchPath(pbd.getDataPath())
+    self.client.setGravity(*self._config.gravity)
+    self.client.setPhysicsEngineParameter(fixedTimeStep=self._config.dt, 
+                                          numSubSteps=1)
+
+    self.plane = self.client.loadURDF('plane.urdf')
+    self.load_bodies()
+
+    self.obs_factory = obs.ObservationFactory(self.client)
+    self.reward_factory = rewards.RewardFactory(self.client)
+    self.termination_factory = terms.TerminationFactory()
+
+    self.reset(init_call=True)

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -26,14 +26,13 @@ class Solo8BaseEnv(gym.Env, ABC):
       realtime (bool): Whether or not to run the simulation in real time. 
         Defaults to False.
     """
-    self._realtime = realtime
-    self._config = config
+    self.config = config
 
     self.client = bc.BulletClient(
       connection_mode=p.GUI if use_gui else p.DIRECT)
     self.client.setAdditionalSearchPath(pbd.getDataPath())
-    self.client.setGravity(*self._config.gravity)
-    self.client.setPhysicsEngineParameter(fixedTimeStep=self._config.dt, 
+    self.client.setGravity(*self.config.gravity)
+    self.client.setPhysicsEngineParameter(fixedTimeStep=self.config.dt, 
                                           numSubSteps=1)
 
     self.plane = self.client.loadURDF('plane.urdf')

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict, List, Tuple
 from abc import ABC, abstractmethod
 
 import gym
@@ -11,6 +12,7 @@ from gym_solo.core import termination as terms
 from gym_solo.core import configs
 from gym_solo.core import obs
 from gym_solo.core import rewards
+import gym_solo.solo_types as solo_types
 
 
 class Solo8BaseEnv(ABC, gym.Env):
@@ -44,19 +46,6 @@ class Solo8BaseEnv(ABC, gym.Env):
     self.reset(init_call=True)
 
   @abstractmethod
-  def reset(self, init_call: bool = False):
-    """Reset the environment.
-    
-    For best results, this method should be deterministic; i.e. the environment
-    should return to the same state everytime this method is called.
-
-    Args:
-      init_call (bool, optional): If this function is being called from the init
-        function. Defaults to False.
-    """
-    pass
-
-  @abstractmethod
   def load_bodies(self):
     """Load the bodies into the environment. 
     
@@ -74,6 +63,35 @@ class Solo8BaseEnv(ABC, gym.Env):
     Returns:
       gym.Space: A Space representing the domain of valid moves for the
         agent.
+    """
+    pass
+
+  @abstractmethod
+  def reset(self, init_call: bool = False):
+    """Reset the environment.
+    
+    For best results, this method should be deterministic; i.e. the environment
+    should return to the same state everytime this method is called.
+
+    Args:
+      init_call (bool, optional): If this function is being called from the init
+        function. Defaults to False.
+    """
+    pass
+
+  @abstractmethod
+  def step(self, action: List[float]) -> Tuple[solo_types.obs, float, bool, 
+                                                Dict[Any, Any]]:
+    """Have the agent apply the action in the environment.
+
+    Args:
+        action (List[float]): The action for the agent to take. Requires that
+        this conforms to self.action_space.
+
+    Returns:
+      Tuple[solo_types.obs, float, bool, Dict[Any, Any]]: A tuple of the next
+        observation, the reward for that step, whether or not the episode 
+        terminates, and an info dict for misc diagnostic details.
     """
     pass
 

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -1,4 +1,5 @@
-import abc
+from abc import ABC, abstractmethod
+
 import gym
 import pybullet as p
 import pybullet_data as pbd
@@ -10,7 +11,7 @@ from gym_solo.core import obs
 from gym_solo.core import rewards
 
 
-class Solo8BaseEnv(gym.Env, abc.ABC):
+class Solo8BaseEnv(gym.Env, ABC):
   """Solo 8 abstract base environment."""
   def __init__(self, config: configs.Solo8BaseConfig, use_gui: bool, 
                realtime: bool):
@@ -41,3 +42,16 @@ class Solo8BaseEnv(gym.Env, abc.ABC):
     self.termination_factory = terms.TerminationFactory()
 
     self.reset(init_call=True)
+
+  @abstractmethod
+  def reset(init_call: bool = False):
+    """Reset the environment.
+    
+    For best results, this method should be deterministic; i.e. the environment
+    should return to the same state everytime this method is called.
+
+    Args:
+      init_call (bool, optional): If this function is being called from the init
+        function. Defaults to False.
+    """
+    pass

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -15,8 +15,7 @@ from gym_solo.core import rewards
 
 class Solo8BaseEnv(ABC, gym.Env):
   """Solo 8 abstract base environment."""
-  def __init__(self, config: configs.Solo8BaseConfig, use_gui: bool, 
-               realtime: bool):
+  def __init__(self, config: configs.Solo8BaseConfig, use_gui: bool):
     """Create a solo8 env.
 
     Args:

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -67,7 +67,18 @@ class Solo8BaseEnv(ABC, gym.Env):
     pass
 
   @property
-  def observation_space(self):
+  @abstractmethod
+  def action_space(self) -> gym.Space:
+    """Get the action space of the agent.
+
+    Returns:
+      gym.Space: A Space representing the domain of valid moves for the
+        agent.
+    """
+    pass
+
+  @property
+  def observation_space(self) -> gym.Space:
     """Get the agent's observation space.
 
     Returns:

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -24,8 +24,6 @@ class Solo8BaseEnv(ABC, gym.Env):
       config (configs.Solo8BaseConfig): The SoloConfig. Defaults to None.
       use_gui (bool): Whether or not to show the pybullet GUI. Defaults to 
         False.
-      realtime (bool): Whether or not to run the simulation in real time. 
-        Defaults to False.
     """
     self.config = config
 

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -13,7 +13,7 @@ from gym_solo.core import obs
 from gym_solo.core import rewards
 
 
-class Solo8BaseEnv(gym.Env, ABC):
+class Solo8BaseEnv(ABC, gym.Env):
   """Solo 8 abstract base environment."""
   def __init__(self, config: configs.Solo8BaseConfig, use_gui: bool, 
                realtime: bool):

--- a/gym_solo/envs/solo8_base_env.py
+++ b/gym_solo/envs/solo8_base_env.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
 
 import gym
+import numpy as np
 import pybullet as p
 import pybullet_data as pbd
 import pybullet_utils.bullet_client as bc
+import random
 
 from gym_solo.core import termination as terms
 from gym_solo.core import configs
@@ -65,3 +67,16 @@ class Solo8BaseEnv(gym.Env, ABC):
     be added via the self.client interface.
     """
     pass
+
+  def _close(self):
+    """Soft shutdown the environment."""
+    self.client.disconnect()
+
+  def _seed(self, seed: int) -> None:
+    """Set the seeds for random and numpy
+
+    Args:
+      seed (int): The seed to set
+    """
+    np.random.seed(seed)
+    random.seed(seed)

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
-import pkg_resources
 import pybullet as p
 import pybullet_data as pbd
 import pybullet_utils.bullet_client as bc

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -52,6 +52,16 @@ class Solo8VanillaEnv(Solo8BaseEnv):
 
   @property
   def action_space(self) -> gym.Space:
+    """The action space of the agent.
+    
+    Aka what actions are "legal" for the agent to carry out.
+
+    Raises:
+      ValueError: Invalid action space
+
+    Returns:
+      gym.Space: The valid actions that the agent can take.
+    """
     if self._action_space:
       return self._action_space
     else:

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -9,12 +9,13 @@ import random
 import time
 
 import gym
-from gym import error, spaces
+from gym import spaces
 
 from gym_solo.core.configs import Solo8BaseConfig
 from gym_solo.core import obs
 from gym_solo.core import rewards
 from gym_solo.core import termination as terms
+from gym_solo.envs import Solo8BaseEnv
 
 from gym_solo import solo_types
 
@@ -38,37 +39,23 @@ class Solo8VanillaConfig(Solo8BaseConfig):
   }
 
 
-class Solo8VanillaEnv(gym.Env):
+class Solo8VanillaEnv(Solo8BaseEnv):
   """An unmodified solo8 gym environment.
   
   Note that the model corresponds to the solo8v2.
   """
   def __init__(self, use_gui: bool = False, realtime: bool = False, 
-               config=None, **kwargs) -> None:
+               config=None, **kwargs):
     """Create a solo8 env"""
     self._realtime = realtime
-    self._config = config
+    super().__init__(config or Solo8VanillaConfig(), use_gui)
 
-    self.client = bc.BulletClient(
-      connection_mode=p.GUI if use_gui else p.DIRECT)
-    self.client.setAdditionalSearchPath(pbd.getDataPath())
-    self.client.setGravity(*self._config.gravity)
-    self.client.setPhysicsEngineParameter(fixedTimeStep=self._config.dt, 
-                                          numSubSteps=1)
-
-    self.plane = self.client.loadURDF('plane.urdf')
-    self.robot, joint_cnt = self._load_robot()
-
-    self.obs_factory = obs.ObservationFactory(self.client)
-    self.reward_factory = rewards.RewardFactory(self.client)
-    self.termination_factory = terms.TerminationFactory()
-
-    self._zero_gains = np.zeros(joint_cnt)
-    self.action_space = spaces.Box(-self._config.max_motor_rotation, 
-                                   self._config.max_motor_rotation,
-                                   shape=(joint_cnt,))
-    
-    self.reset(init_call=True)
+  @property
+  def action_space(self) -> gym.Space:
+    if self._action_space:
+      return self._action_space
+    else:
+      raise ValueError('No valid action space')
 
   def step(self, action: List[float]) -> Tuple[solo_types.obs, float, bool, 
                                                 Dict[Any, Any]]:
@@ -86,11 +73,11 @@ class Solo8VanillaEnv(gym.Env):
     self.client.setJointMotorControlArray(
       self.robot, np.arange(self.action_space.shape[0]), p.POSITION_CONTROL, 
       targetPositions = action, 
-      forces = [self._config.motor_torque_limit] * self.action_space.shape[0])
+      forces = [self.config.motor_torque_limit] * self.action_space.shape[0])
     self.client.stepSimulation()
 
     if self._realtime:
-      time.sleep(self._config.dt)
+      time.sleep(self.config.dt)
 
     obs_values, obs_labels = self.obs_factory.get_obs()
     reward = self.reward_factory.get_reward()
@@ -107,11 +94,11 @@ class Solo8VanillaEnv(gym.Env):
       solo_types.obs: The initial observation of the space.
     """
     self.client.removeBody(self.robot)
-    self.robot, joint_cnt = self._load_robot()
+    self.load_bodies()
     
     joint_ordering = [self.client.getJointInfo(self.robot, j)[1].decode('UTF-8')
-                      for j in range(joint_cnt)]
-    positions = [self._config.starting_joint_pos[j] for j in joint_ordering]
+                      for j in range(self._joint_cnt)]
+    positions = [self.config.starting_joint_pos[j] for j in joint_ordering]
 
     # Let the robot lay down flat, as intended. Note that this is a hack
     # around modifying the URDF, but that should really be handled in the
@@ -120,7 +107,7 @@ class Solo8VanillaEnv(gym.Env):
       self.client.setJointMotorControlArray(
         self.robot, np.arange(self.action_space.shape[0]), p.POSITION_CONTROL, 
         targetPositions = positions, 
-        forces = [self._config.motor_torque_limit] * self.action_space.shape[0])
+        forces = [self.config.motor_torque_limit] * self.action_space.shape[0])
 
       self.client.stepSimulation()
     
@@ -130,37 +117,30 @@ class Solo8VanillaEnv(gym.Env):
       obs_values, _ = self.obs_factory.get_obs()
       return obs_values
 
-  def _load_robot(self) -> Tuple[int, int]:
+  def load_bodies(self) -> Tuple[int, int]:
     """Load the robot from URDF and reset the dynamics.
 
     Returns:
         Tuple[int, int]: the id of the robot object and the number of joints.
     """
     robot_id = self.client.loadURDF(
-      self._config.urdf, self._config.robot_start_pos, 
+      self.config.urdf, self.config.robot_start_pos, 
       self.client.getQuaternionFromEuler(
-        self._config.robot_start_orientation_euler),
+        self.config.robot_start_orientation_euler),
       flags=p.URDF_USE_INERTIA_FROM_FILE, useFixedBase=False)
 
     joint_cnt = self.client.getNumJoints(robot_id)
     for joint in range(joint_cnt):
       self.client.changeDynamics(robot_id, joint, 
-                                 linearDamping=self._config.linear_damping, 
-                                 angularDamping=self._config.angular_damping, 
-                                 restitution=self._config.restitution, 
-                                 lateralFriction=self._config.lateral_friction)
+                                 linearDamping=self.config.linear_damping, 
+                                 angularDamping=self.config.angular_damping, 
+                                 restitution=self.config.restitution, 
+                                 lateralFriction=self.config.lateral_friction)
+    
+    self.robot = robot_id
+    self._joint_cnt = joint_cnt
+    self._zero_gains = np.zeros(self._joint_cnt)
 
-    return robot_id, joint_cnt
-
-  def _close(self) -> None:
-    """Soft shutdown the environment. """
-    self.client.disconnect()
-
-  def _seed(self, seed: int) -> None:
-    """Set the seeds for random and numpy
-
-    Args:
-      seed (int): The seed to set
-    """
-    np.random.seed(seed)
-    random.seed(seed)
+    self._action_space = spaces.Box(-self.config.max_motor_rotation, 
+                                   self.config.max_motor_rotation,
+                                   shape=(self._joint_cnt,))

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -129,11 +129,6 @@ class Solo8VanillaEnv(gym.Env):
     else:
       obs_values, _ = self.obs_factory.get_obs()
       return obs_values
-  
-  @property
-  def observation_space(self):
-    # TODO: Write tests for this function
-    return self.obs_factory.get_observation_space()
 
   def _load_robot(self) -> Tuple[int, int]:
     """Load the robot from URDF and reset the dynamics.

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -12,6 +12,7 @@ from gym_solo.core import termination as terms
 from gym_solo.core import configs
 from gym_solo.core import obs
 from gym_solo.core import rewards
+from gym_solo import testing
 
 
 class SimpleSoloEnv(Solo8BaseEnv):
@@ -104,6 +105,11 @@ class TestSolo8BaseEnv(unittest.TestCase):
 
       self.assertEqual(numpy_control, float(np.random.rand(1)))
       self.assertEqual(random_control, random.random())
+
+  def test_obs_space(self):
+    self.env.obs_factory.register_observation(testing.CompliantObs(None))
+    self.assertEqual(self.env.observation_space, 
+                     self.env.obs_factory.get_observation_space())
 
 
 if __name__ == '__main__':

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -3,7 +3,9 @@ import unittest
 
 
 class TestSolo8BaseEnv(unittest.TestCase):
-  pass
+  def test_abstract_init(self):
+    with self.assertRaises(TypeError):
+      env = Solo8BaseEnv()
 
 
 if __name__ == '__main__':

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -1,11 +1,44 @@
 from gym_solo.envs import Solo8BaseEnv
 import unittest
 
+from parameterized import parameterized
+from unittest import mock
+import pybullet as p
+import pybullet_utils.bullet_client as bc
+
+from gym_solo.core import configs
+
+
+class SimpleSoloEnv(Solo8BaseEnv):
+  def __init__(self, *args, **kwargs):
+    self.reset_call = None
+    self.load_bodies_call = None
+
+    super().__init__(*args, **kwargs)
+
+  def reset(self, init_call: bool):
+    self.reset_call = init_call
+  
+  def load_bodies(self):
+    self.load_bodies_call = True
+
 
 class TestSolo8BaseEnv(unittest.TestCase):
   def test_abstract_init(self):
     with self.assertRaises(TypeError):
       env = Solo8BaseEnv()
+
+  @parameterized.expand([
+    ('nogui', False, p.DIRECT),
+    ('gui', True, p.GUI),
+  ])
+  @mock.patch('pybullet_utils.bullet_client.BulletClient')
+  def test_GUI(self, name, use_gui, expected_ui, mock_client):
+    env = SimpleSoloEnv(configs.Solo8BaseConfig(), use_gui, False)
+
+    mock_client.assert_called_with(connection_mode=expected_ui)
+    self.assertTrue(env.load_bodies_call)
+    self.assertTrue(env.reset_call)
 
 
 if __name__ == '__main__':

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -30,6 +30,9 @@ class TestSolo8BaseEnv(unittest.TestCase):
     with mock.patch('pybullet_utils.bullet_client.BulletClient') as self.mock_client:
       self.env = SimpleSoloEnv(configs.Solo8BaseConfig(), False, False)
 
+  def tearDown(self):
+    self.env._close()
+
   def test_abstract_init(self):
     with self.assertRaises(TypeError):
       env = Solo8BaseEnv()

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -4,6 +4,7 @@ import unittest
 from parameterized import parameterized
 from unittest import mock
 
+import gym
 import importlib
 import pybullet as p
 import pybullet_utils.bullet_client
@@ -16,6 +17,8 @@ from gym_solo import testing
 
 
 class SimpleSoloEnv(Solo8BaseEnv):
+  action_space = gym.spaces.Box(3,4, shape=(3, 4))
+
   def __init__(self, *args, **kwargs):
     self.reset_call = None
     self.load_bodies_call = None

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -31,6 +31,9 @@ class SimpleSoloEnv(Solo8BaseEnv):
   def load_bodies(self):
     self.load_bodies_call = True
 
+  def step(self):
+    pass
+
 
 class TestSolo8BaseEnv(unittest.TestCase):
   def setUp(self):

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -1,0 +1,10 @@
+from gym_solo.envs import Solo8BaseEnv
+import unittest
+
+
+class TestSolo8BaseEnv(unittest.TestCase):
+  pass
+
+
+if __name__ == '__main__':
+  unittest.main() 

--- a/gym_solo/envs/test_solo8_base_env.py
+++ b/gym_solo/envs/test_solo8_base_env.py
@@ -28,7 +28,7 @@ class SimpleSoloEnv(Solo8BaseEnv):
 class TestSolo8BaseEnv(unittest.TestCase):
   def setUp(self):
     with mock.patch('pybullet_utils.bullet_client.BulletClient') as self.mock_client:
-      self.env = SimpleSoloEnv(configs.Solo8BaseConfig(), False, False)
+      self.env = SimpleSoloEnv(configs.Solo8BaseConfig(), False)
 
   def tearDown(self):
     self.env._close()
@@ -37,13 +37,26 @@ class TestSolo8BaseEnv(unittest.TestCase):
     with self.assertRaises(TypeError):
       env = Solo8BaseEnv()
 
+  def test_init(self):
+    config = configs.Solo8BaseConfig()
+    gui = False
+
+    with mock.patch('pybullet_utils.bullet_client.BulletClient') as mock_client:
+      env = SimpleSoloEnv(config, gui)
+
+    with self.subTest('config'):
+      self.assertEqual(env.config, config)
+    
+    # with self.subTest('client'):
+    #   mock_client.setAdditionalSearchPath.assert_called_once()
+
   @parameterized.expand([
     ('nogui', False, p.DIRECT),
     ('gui', True, p.GUI),
   ])
   @mock.patch('pybullet_utils.bullet_client.BulletClient')
   def test_GUI(self, name, use_gui, expected_ui, mock_client):
-    env = SimpleSoloEnv(configs.Solo8BaseConfig(), use_gui, False)
+    env = SimpleSoloEnv(configs.Solo8BaseConfig(), use_gui)
 
     mock_client.assert_called_with(connection_mode=expected_ui)
     self.assertTrue(env.load_bodies_call)

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -44,18 +44,11 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     env.step(env.action_space.sample())
     self.assertTrue(mock_time.called)
 
-  @parameterized.expand([
-    ('default', {}, p.DIRECT),
-    ('nogui', {'use_gui': False}, p.DIRECT),
-    ('gui', {'use_gui': True}, p.GUI),
-  ])
   @mock.patch('pybullet_utils.bullet_client.BulletClient')
   @mock.patch.object(solo_env.Solo8VanillaEnv, 'reset')
-  def test_GUI(self, name, kwargs, expected_ui, fake_reset, 
-               mock_client):
-    env = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig(),
-                                   **kwargs)
-    mock_client.assert_called_with(connection_mode=expected_ui)
+  def test_GUI_default(self, fake_reset, mock_client):
+    solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
+    mock_client.assert_called_with(connection_mode=p.DIRECT)
 
   def test_action_space(self):
     limit = 2 * np.pi

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -62,6 +62,11 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     
     self.assertEqual(env.action_space, space)
 
+  def test_invalid_action_space(self):
+    self.env._action_space = None
+    with self.assertRaises(ValueError):
+      self.env.action_space
+
   def test_actions(self):
     no_op = np.zeros(self.env.action_space.shape[0])
     

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -123,11 +123,6 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     obs, reward, done, info = self.env.step(self.env.action_space.sample())
     self.assertEqual(reward, 1)
 
-  def test_observation_space(self):
-    o = CompliantObs(None)
-    self.env.obs_factory.register_observation(o)
-    self.assertEqual(o.observation_space, self.env.observation_space)
-
   def test_disjoint_environments(self):
     env1 = solo_env.Solo8VanillaEnv(config=solo_env.Solo8VanillaConfig())
     env1.obs_factory.register_observation(solo_obs.TorsoIMU(env1.robot))

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -43,32 +43,6 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     
     env.step(env.action_space.sample())
     self.assertTrue(mock_time.called)
-    
-  def test_seed(self):
-    seed = 69
-    self.env._seed(seed)
-
-    import numpy as np
-    import random
-    
-    numpy_control = float(np.random.rand(1))
-    random_control = random.random()
-
-    with self.subTest('random seed'):
-      importlib.reload(np)
-      importlib.reload(random)
-
-      self.assertNotEqual(numpy_control, float(np.random.rand(1)))
-      self.assertNotEqual(random_control, random.random())
-
-    with self.subTest('same seed'):
-      importlib.reload(np)
-      importlib.reload(random)
-
-      self.env._seed(seed)
-
-      self.assertEqual(numpy_control, float(np.random.rand(1)))
-      self.assertEqual(random_control, random.random())
 
   @parameterized.expand([
     ('default', {}, p.DIRECT),


### PR DESCRIPTION
Fixes #10. Basically stripped out as much (forseeable) redundant logic and plopped it into a base environment class `Solo8BaseEnv`.

Thus, if someone wanted to create a new environment, all that they would need to do is to create a new subclass and implement the following methods:
* `load_bodies` - load the robot into the env
* `action_space`
* `reset`
* `step`

..and that's it!