### PR TITLE
[Hotfix] Fix Episode Termination

### DIFF
--- a/examples/solo8_vanilla/episodes.py
+++ b/examples/solo8_vanilla/episodes.py
@@ -1,0 +1,40 @@
+""" A gentle demo which runs the simulation for 1000 timesteps for 10 episodes.
+"""
+import gym
+import numpy as np
+
+import gym_solo
+from gym_solo.envs import solo8v2vanilla
+from gym_solo.core import obs
+from gym_solo.core import rewards
+from gym_solo.core import termination as terms
+
+
+if __name__ == '__main__':
+  config = solo8v2vanilla.Solo8VanillaConfig()
+  env = gym.make('solo8vanilla-v0', use_gui=True, realtime=True, config=config)
+
+  env.obs_factory.register_observation(obs.TorsoIMU(env.robot))
+  env.reward_factory.register_reward(1,rewards.UprightReward(env.robot))
+  env.termination_factory.register_termination(terms.TimeBasedTermination(1000))
+
+  try:
+    print("""\n
+          =============================================
+              Solo 8 v2 Vanilla Episode Test
+              
+          Simulation Active.
+          
+          Exit with ^C.
+          =============================================
+          """)
+
+    for i in range(10):
+      env.reset()
+      done = False
+      while not done:
+        _, _, done, _ = env.step(np.zeros(env.action_space.shape))
+      print('Episode {} done'.format(i))
+
+  except KeyboardInterrupt:
+    pass

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -120,6 +120,7 @@ class Solo8VanillaEnv(Solo8BaseEnv):
         forces = [self.config.motor_torque_limit] * self.action_space.shape[0])
 
       self.client.stepSimulation()
+    self.termination_factory.reset()
     
     if init_call:
       return np.empty(shape=(0,)), []

--- a/gym_solo/envs/test_solo8v2vanilla.py
+++ b/gym_solo/envs/test_solo8v2vanilla.py
@@ -103,14 +103,18 @@ class TestSolo8v2VanillaEnv(unittest.TestCase):
     base_pos, base_or = p.getBasePositionAndOrientation(self.env.robot)
     
     action = np.array([5.] * self.env.action_space.shape[0])
-    for i in range(100):
+    for _ in range(100):
       self.env.step(action)
+    self.assertEqual(
+      self.env.termination_factory._terminations[0].reset_counter, 1)
       
     new_pos, new_or = p.getBasePositionAndOrientation(self.env.robot)
     self.assert_array_not_almost_equal(base_pos, new_pos)
     self.assert_array_not_almost_equal(base_or, new_or)
 
     self.env.reset()
+    self.assertEqual(
+      self.env.termination_factory._terminations[0].reset_counter, 2)
 
     new_pos, new_or = p.getBasePositionAndOrientation(self.env.robot)
     np.testing.assert_array_almost_equal(base_pos, new_pos)


### PR DESCRIPTION
Seems to be a bug in the implementation of #29 and #19. Basically the env's `reset()` function never calls the `termination_factory.reset()` function, so the episodes never ended!

I'm not the biggest fan of how this is implemented in this PR, as it is in the child class instead of the base class. While this is a bit of an anti-pattern, I feel like it's better down the line to allow users to have the ability to control when their terminations are reset.