### PR TITLE
[Hotfix] Clean up xfvb processes after test

### DIFF
--- a/gym_solo/envs/test_solo8v2vanilla_realtime.py
+++ b/gym_solo/envs/test_solo8v2vanilla_realtime.py
@@ -12,6 +12,15 @@ from gym_solo import testing
 
 
 class TestSolo8v2VanillaRealtimeEnv(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.display = pyvirtualdisplay.Display(visible=False, size=(1400, 900))
+    cls.display.start()
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.display.stop()
+
   def test_init_non_realtime(self):
     config = solo_env.RealtimeSolo8VanillaConfig()
     config.dt = 21
@@ -38,9 +47,6 @@ class TestSolo8v2VanillaRealtimeEnv(unittest.TestCase):
     self.assertEqual(env.client.stepSimulation(), solo_types.no_op)
 
   def test_step_and_reset(self):
-    display = pyvirtualdisplay.Display(visible=False, size=(1400, 900))
-    display.start()
-
     # Realtime only works in GUI mode
     env = solo_env.RealtimeSolo8VanillaEnv(use_gui=True)
     env.obs_factory.register_observation(obs.TorsoIMU(env.robot))


### PR DESCRIPTION
Pybullet realtime physics don't work unless it is running in GUI mode. This isn't a big deal when we are running the simulation for ourselves; however, to write deterministic tests, we need to create a virtual display.

We're using `pyvirtualdisplay` for this, but the display process never ever terminated so they were just hanging. This should take care of all of that.