### PR TITLE
[Hotfix] Expose get_obs() to realtime env API

### DIFF
--- a/examples/solo8_vanilla/realtime.py
+++ b/examples/solo8_vanilla/realtime.py
@@ -10,8 +10,6 @@ import numpy as np
 import gym_solo
 from gym_solo.envs import solo8v2vanilla
 from gym_solo.core import obs
-from gym_solo.core import rewards
-from gym_solo.core import termination as terms
 
 
 if __name__ == '__main__':

--- a/gym_solo/envs/solo8v2vanilla.py
+++ b/gym_solo/envs/solo8v2vanilla.py
@@ -105,10 +105,9 @@ class Solo8VanillaEnv(Solo8BaseEnv):
     """
     self.client.removeBody(self.robot)
     self.load_bodies()
-    
-    joint_ordering = [self.client.getJointInfo(self.robot, j)[1].decode('UTF-8')
-                      for j in range(self._joint_cnt)]
-    positions = [self.config.starting_joint_pos[j] for j in joint_ordering]
+
+    positions = [self.config.starting_joint_pos[j] 
+                 for j in self.joint_ordering]
 
     # Let the robot lay down flat, as intended. Note that this is a hack
     # around modifying the URDF, but that should really be handled in the
@@ -140,18 +139,19 @@ class Solo8VanillaEnv(Solo8BaseEnv):
         self.config.robot_start_orientation_euler),
       flags=p.URDF_USE_INERTIA_FROM_FILE, useFixedBase=False)
 
-    joint_cnt = self.client.getNumJoints(robot_id)
-    for joint in range(joint_cnt):
+    self._joint_cnt = self.client.getNumJoints(robot_id)
+    for joint in range(self._joint_cnt):
       self.client.changeDynamics(robot_id, joint, 
                                  linearDamping=self.config.linear_damping, 
                                  angularDamping=self.config.angular_damping, 
                                  restitution=self.config.restitution, 
                                  lateralFriction=self.config.lateral_friction)
+
     
     self.robot = robot_id
-    self._joint_cnt = joint_cnt
     self._zero_gains = np.zeros(self._joint_cnt)
-
+    self.joint_ordering = [self.client.getJointInfo(self.robot, j)[1].decode('UTF-8')
+                           for j in range(self._joint_cnt)]
     self._action_space = spaces.Box(-self.config.max_motor_rotation, 
                                    self.config.max_motor_rotation,
                                    shape=(self._joint_cnt,))

--- a/gym_solo/envs/solo8v2vanilla_realtime.py
+++ b/gym_solo/envs/solo8v2vanilla_realtime.py
@@ -66,3 +66,12 @@ class RealtimeSolo8VanillaEnv(Solo8VanillaEnv):
     super().reset(*args, **kwargs)
     # Since stepSimulation() is a noop, need to use time to reset the bot
     time.sleep(1)
+
+  def get_obs(self):
+    """Get the current observation of the environment.
+
+    Note this is different from the OpenAI gym `get_obs()` as this is
+    a realtime simulation, so `get_obs()` can have different results even
+    if `env.step()` isn't called.
+    """
+    return self.obs_factory.get_obs()


### PR DESCRIPTION
For our simulations, the envs are running in realtime. That means that the observation can change even if `env.step()` is never called. 

This PR exposes a `get_obs()` method to the top level API so that the master can query the robot sensors when needed. 