### PR TITLE
Add Linearly Shaped Reward Function

### DIFF
--- a/gym_solo/core/rewards.py
+++ b/gym_solo/core/rewards.py
@@ -447,9 +447,12 @@ def linear(x: float, target: float, span: float, symmetric = False) -> float:
       span evaluates to 0. Every value in between is evalulated as the linear
       interpolation between `target` and `span`.
   """
+  if span == 0:
+    return 1. if x == target else 0.
+
   x_delta = x - target
   
-  if abs(x_delta) > span:
+  if abs(x_delta) > abs(span):
     return 0.
   
   ratio = x_delta / span

--- a/gym_solo/core/rewards.py
+++ b/gym_solo/core/rewards.py
@@ -373,7 +373,15 @@ class TorsoHeightReward(Reward):
                      margin=self._soft_margin)
 
 
-def tolerance(x: float, bounds: Tuple[float, float] = (0., 0.), 
+def tolerance(*args, **kwargs):
+  """Filler function while other sloped methods are being put in. Most functions
+    will switch out their tolerance function, so it doesn't make sense to do a 
+    giant refactor just yet.
+  """
+  return gaussian(*args, **kwargs)
+
+
+def gaussian(x: float, bounds: Tuple[float, float] = (0., 0.), 
               margin: float = 0., margin_value: float = .1):
   """
   Create a sloped reward function about a given bounds range.
@@ -421,3 +429,31 @@ def tolerance(x: float, bounds: Tuple[float, float] = (0., 0.),
     value = np.where(within_bounds, 1., values)
   
   return float(value) if np.isscalar(x) else value
+
+
+def linear(x: float, target: float, span: float, symmetric = False) -> float:
+  """Create a linearly sloped reward space.
+
+  Args:
+    x (float): Value to evaluate the reward space at.
+    target (float): The value s.t. when x == target, this function 
+      returns 1.
+    span (float): The value s.t. when x >= target + span, this function returns 
+      0. symmetric (bool, optional): If true, then this function works if x is 
+      over or under target. Defaults to False.
+
+  Returns:
+    float: A value between 0 and 1. x == target evaluates to 1, x >= target +
+      span evaluates to 0. Every value in between is evalulated as the linear
+      interpolation between `target` and `span`.
+  """
+  x_delta = x - target
+  
+  if abs(x_delta) > span:
+    return 0.
+  
+  ratio = x_delta / span
+  if not symmetric and ratio < 0:
+    return 0
+  
+  return 1 - abs(ratio)

--- a/gym_solo/core/test_rewards.py
+++ b/gym_solo/core/test_rewards.py
@@ -307,13 +307,13 @@ class TestRewardUtilities(unittest.TestCase):
     ('at_margin_default_value', 2, (-1, 1), 1, 1e-8, 1e-8),
     ('at_margin_margin_value', 2, (-1, 1), 1, .25, .25),
   ])
-  def test_tolerance(self, name, x, bounds, margin, margin_value, 
+  def test_gaussian(self, name, x, bounds, margin, margin_value, 
                      expected_value):
     # Floating point issuses cause flakiness when doing an exact comparision
     self.assertAlmostEqual(rewards.tolerance(x, bounds, margin, margin_value),
                      expected_value)
 
-  def test_tolerance_relative(self):
+  def test_gaussian_relative(self):
     bounds = (0,0)
     margin = 1.
     margin_value = .25
@@ -327,15 +327,15 @@ class TestRewardUtilities(unittest.TestCase):
     self.assertAlmostEqual(val2, margin_value)
     self.assertGreater(val1, val2)
 
-  def test_tolerance_bounds_error(self):
+  def test_gaussian_bounds_error(self):
     with self.assertRaises(ValueError):
       rewards.tolerance(0, bounds=(1, 0))
 
-  def test_tolerance_margin_error(self):
+  def test_gaussian_margin_error(self):
     with self.assertRaises(ValueError):
       self.assertRaises(rewards.tolerance(0, margin=-1))
 
-  def test_tolerance_margin_value_error(self):
+  def test_gaussian_margin_value_error(self):
     with self.assertRaises(ValueError):
       self.assertRaises(rewards.tolerance(0, margin_value=0))
 

--- a/gym_solo/core/test_rewards.py
+++ b/gym_solo/core/test_rewards.py
@@ -339,5 +339,19 @@ class TestRewardUtilities(unittest.TestCase):
     with self.assertRaises(ValueError):
       self.assertRaises(rewards.tolerance(0, margin_value=0))
 
+  @parameterized.expand([
+    ('at_target', 5, 0, False, 5, 1.),
+    ('at_span', 5, 2, False, 7, 0.),
+    ('negative_span', 5, -4, False, 2, 0.25),
+    ('past_span_positive', 5, 4, False, 10, 0),
+    ('past_span_negative', 5, -4, False, 0, 0),
+    ('in_span_positive_symmetric', 5, 4, True, 6, 0.75),
+    ('in_flipped_span_positive_symmetric', 5, 4, True, 4, 0.75),
+    ('in_span_negative_symmetric', 5, -4, True, 4, 0.75),
+    ('in_flipped_span_negative_symmetric', 5, -4, True, 6, 0.75),
+  ])
+  def test_linear(self, name, target, span, symmetric, x, expected):
+    self.assertEqual(rewards.linear(x, target, span, symmetric), expected)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Create a generic reward function that is linearly shaped. Right now all, the default reward function is shaped like a Gaussian. I'm probably going to be replacing all instances of that soon (I have to rewrite some functions) so I just hot-patched it for now and I'll clean it up once everything else has been changed.

I'm diffing this off of #55 just so reviewing is easier. Once #55 is merged in, I think this can (?) be directly merged into master. And if not, I'll just change the location and that should be an easy approval.